### PR TITLE
Improving build process 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,7 @@ test:
 build:
 	go build -o kzgcli ./cmd/kzgcli
 .PHONY: build
+
+bench:
+	go test ./... -run=none -bench=.
+.PHONY: bench

--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,7 @@ lint:
 test:
 	go test ./... -race
 .PHONY: test
+
+build:
+	go build -o kzgcli ./cmd/kzgcli
+.PHONY: build

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Currently, the ceremony sequencer is in testnet mode, but everything described i
 
 ### Step 1 - Get the `kzgcli` CLI command
 The `kzgcli` command is the CLI of this ceremony client, you can get it in different ways:
-- Compiling from source: For this, you'll need to have installed the `go` compiler. Pull this repo, and run `make build` or `go build -o kzgcli ./cmd/kzgcli`. This will leave the `kzgcli` binary in your current folder (you might want to `sudo mv kzgcli /usr/local` or your PATH for convenience).
+- Compiling from source: For this, you'll need to have installed the `go` compiler. Pull this repo, and run `make build` or `go build -o kzgcli ./cmd/kzgcli`. This will leave the `kzgcli` binary in your current folder (you might want to `sudo mv kzgcli /usr/local/bin` or your PATH for convenience).
 - Download binaries from the [releases section](https://github.com/jsign/go-kzg-ceremony-client/releases).
 
 


### PR DESCRIPTION
* Added `make build`
* Added `make bench`
* Modified `README.md` to encourage users to move the `kzgcli` executable to `usr/local/bin`, not `usr/local`

Tested on 

```
goos: darwin
goarch: amd64
pkg: github.com/jsign/go-kzg-ceremony-client/contribution
cpu: VirtualApple @ 2.50GHz```

Feel free to squash commits!

